### PR TITLE
Allow multi-byte character literals

### DIFF
--- a/clexer.c
+++ b/clexer.c
@@ -228,11 +228,6 @@ char const *examinechar(struct clexer *cl, char const *input)
 	} else {
 	    ++cl->charquote;
 	}
-	if (cl->charquote > 2) {		/* optional */
-	    error(errBadCharLiteral);
-	    cl->state |= F_EndOfLine;
-	    return input;
-	}
     } else if (cl->state & F_InString) {
 	if (*in == '\\')
 	    readwhack(cl, in);


### PR DESCRIPTION
Removed the optional length check when parsing character literals (e.g. `'IHDR'`), making `cppp` able to process header files that make use of this commonly-used extension.